### PR TITLE
Fix gguf model registration with no models dir

### DIFF
--- a/llm_llama_cpp.py
+++ b/llm_llama_cpp.py
@@ -50,6 +50,7 @@ def _ensure_models_file():
 
 @llm.hookimpl
 def register_models(register):
+    register(LlamaGGUF())
     directory = llm.user_dir() / "llama-cpp"
     models_file = directory / "models.json"
     if not models_file.exists():
@@ -64,7 +65,6 @@ def register_models(register):
             ),
             aliases=details["aliases"],
         )
-    register(LlamaGGUF())
 
 
 @llm.hookimpl


### PR DESCRIPTION
Howdy, I was following the steps in [your recent blog post](https://simonwillison.net/2023/Dec/18/mistral/) to get set up on a new machine, and I failed at the last step with:

```
> llm -m gguf -o path mixtral-8x7b-v0.1.Q4_K_M.gguf '[INST] Write a Python function that downloads a file from a URL[/INST]'
Error: 'gguf' is not a known model
```

Here's a quick PR to fix it 😊 It looks like `LlamaGGUF` should be registered in all cases, and the existence check for `models.json` is only relevant for the model-registration logic.

Thank you for such an awesome tool, glad to be able to contribute in a small way!