### PR TITLE
default n_gpu_layers to -1

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,8 +143,8 @@ The following options are available:
 
 - `-o verbose 1` - output more verbose logging
 - `-o max_tokens 100` - max tokens to return. Defaults to 4000.
-- `-o no_gpu 1` - remove the default `n_gpu_layers=1`` argument, which should disable GPU usage
-- `-o n_gpu_layers 10` - increase the `n_gpu_layers` argument to a higher value (the default is `1`)
+- `-o no_gpu 1` - remove the default `n_gpu_layers=-1`` argument, which should disable GPU usage
+- `-o n_gpu_layers 10` - increase the `n_gpu_layers` argument to a higher value (the default is `-1`)
 - `-o n_ctx 1024` - set the `n_ctx` argument to `1024` (the default is `4000`)
 
 For example:

--- a/llm_llama_cpp.py
+++ b/llm_llama_cpp.py
@@ -184,10 +184,10 @@ class LlamaModel(llm.Model):
             description="Whether to print verbose output from the model", default=False
         )
         no_gpu: bool = Field(
-            description="Remove the default n_gpu_layers=1 argument", default=False
+            description="Remove the default n_gpu_layers=-1 argument", default=False
         )
         n_gpu_layers: int = Field(
-            description="Number of GPU layers to use, defaults to 1", default=None
+            description="Number of GPU layers to use, defaults to -1", default=None
         )
         max_tokens: int = Field(
             description="Max tokens to return, defaults to 4000", default=None
@@ -251,7 +251,7 @@ class LlamaModel(llm.Model):
 
     def execute(self, prompt, stream, response, conversation):
         with SuppressOutput(verbose=prompt.options.verbose):
-            kwargs = {"n_ctx": prompt.options.n_ctx or 4000, "n_gpu_layers": 1}
+            kwargs = {"n_ctx": prompt.options.n_ctx or 4000, "n_gpu_layers": -1}
             if prompt.options.no_gpu:
                 kwargs.pop("n_gpu_layers")
             if prompt.options.n_gpu_layers:


### PR DESCRIPTION
As of current, the plugin will use GPU acceleration, but only for a single layer. With `n_gpu_layers`=`-1` llama.cpp will try to put the entire model onto the GPU.

(Side note: It took me ages to figure out why llm was so much slower than llama.cpp's `./main`)